### PR TITLE
feat: support args for input

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ const { log, output, input, time } = require('proc-log')
 
 #### input
 
-* `input.start(fn?)` calls `process.emit('input', 'start')`
+* `input.start(...args)` calls `process.emit('input', 'start', ...args)`
 
-  Used to tell the consumer that the terminal is going to begin reading user input. Returns a function that will call `input.end()` for convenience.
+  Used to tell the consumer that the terminal is going to begin reading user input. Returns a function that will call `input.end(...args)` for convenience.
   
-  This also takes an optional callback which will run `input.end()` on its completion. If the callback returns a `Promise` then `input.end()` will be run during `finally()`.
+  If the first argument is a function, it will be used as a callback which runs `input.end()` on its completion. If the callback returns a `Promise` then `input.end(...args)` will be run during `finally()`.
 
-* `input.end()` calls `process.emit('input', 'end')`
+* `input.end(...args)` calls `process.emit('input', 'end', ...args)`
 
   Used to tell the consumer that the terminal has stopped reading user input.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,10 +122,15 @@ module.exports = {
       end: 'end',
       read: 'read',
     },
-    start: function (fn) {
-      process.emit('input', 'start')
+    start: function (...args) {
+      // Support callback for backwards compatibility and pass args to event
+      let fn
+      if (typeof args[0] === 'function') {
+        fn = args.shift()
+      }
+      process.emit('input', 'start', ...args)
       function end () {
-        return process.emit('input', 'end')
+        return process.emit('input', 'end', ...args)
       }
       if (typeof fn === 'function') {
         const res = fn()
@@ -137,8 +142,8 @@ module.exports = {
       }
       return end
     },
-    end: function () {
-      return process.emit('input', 'end')
+    end: function (...args) {
+      return process.emit('input', 'end', ...args)
     },
     read: function (...args) {
       let resolve, reject

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,7 +123,7 @@ module.exports = {
       read: 'read',
     },
     start: function (...args) {
-      // Support callback for backwards compatibility and pass args to event
+      // Support callback for backwards compatibility and pass additional args to event
       let fn
       if (typeof args[0] === 'function') {
         fn = args.shift()

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ for (const method in procLog) {
     t.matchSnapshot(KEYS, `${method} keys`)
 
     t.strictSame(Object.keys(KEYS), LEVELS, 'all keys are in levels')
-    t.strictSame(Object.values(KEYS), LEVELS, 'all vales are in levels')
+    t.strictSame(Object.values(KEYS), LEVELS, 'all values are in levels')
 
     t.test(`all ${method}.LEVELS have a function in ${method}`, t => {
       for (const level of LEVELS) {
@@ -36,8 +36,6 @@ for (const method in procLog) {
               case 'time.end':
                 t.strictSame(args, [1], 'single arg')
                 break
-              case 'input.start':
-              case 'input.end':
               case 'log.pause':
               case 'log.resume':
                 t.strictSame(args, [], 'no args')
@@ -47,7 +45,7 @@ for (const method in procLog) {
                 t.same(args.slice(2), [1, 'two', [3], { 4: 4 }], 'got expected args')
                 break
               default:
-                t.same(args, [1, 'two', [3], { 4: 4 }], 'got expected args')
+                t.same(args, [1, 'two', [3], { 4: 4 }], `got expected args ${method}.${level}`)
             }
 
             t.end()

--- a/test/input.js
+++ b/test/input.js
@@ -75,5 +75,49 @@ t.test('start and end', t => {
     t.ok(called.end)
   })
 
+  t.test('sync no callback but args', t => {
+    const called = {}
+    const handler = (level, ...args) => {
+      if (level === 'start') {
+        called.start = args
+      } else if (level === 'end') {
+        called.end = args
+        if (called.start && called.end) {
+          t.strictSame(called.start, [{ silent: true }], 'start event gets silent option')
+          t.strictSame(called.end, [{ silent: true }], 'end event gets silent option')
+          t.end()
+        }
+      }
+    }
+
+    process.on('input', handler)
+    t.teardown(() => process.off('input', handler))
+
+    const end = input.start({ silent: true })
+    end()
+  })
+
+  t.test('async no callback but args', async t => {
+    const called = {}
+    const handler = (level, ...args) => {
+      if (level === 'start') {
+        called.start = args
+      } else if (level === 'end') {
+        called.end = args
+        if (called.start && called.end) {
+          t.strictSame(called.start, [{ silent: true }], 'start event gets silent option')
+          t.strictSame(called.end, [{ silent: true }], 'end event gets silent option')
+          t.end()
+        }
+      }
+    }
+
+    process.on('input', handler)
+    t.teardown(() => process.off('input', handler))
+
+    const end = await input.start({ silent: true })
+    end()
+  })
+
   t.end()
 })


### PR DESCRIPTION
Some input processes require additional arguments. For example, password inputs depend on the `{ silent: true }`. This change passes these arguments to the related input processes while keeping compatibility with existing API (i.e. callback for `input.start`).

cc: @wraithgar, I hope this is what you had in mind re: spinner fix. 

## References

Related to https://github.com/npm/cli/pull/8322
